### PR TITLE
Update types.tex

### DIFF
--- a/WhileyLanguageSpecification/src/types.tex
+++ b/WhileyLanguageSpecification/src/types.tex
@@ -424,10 +424,14 @@ A set type describes set values whose elements are subtypes of the element type.
 
 \begin{lstlisting}
 // Adjacency list representation
-type Graph is ([{uint}] es)
+type Graph is ([{int}])
 
-function depthFirstSearch(uint v, Graph graph, {int} visited) => {int}
-    //
+method main(System.Console console):
+    Graph graph = [{0, 2, 3}, {0, 4}, {0, 2}, {1}, {}]
+    {int} visited = depthFirstSearch(3, graph, {-1})
+    console.out.println("returns => " ++ visited)
+
+function depthFirstSearch(int v, Graph graph, {int} visited) => {int}:
     visited = visited + {v}
     // Traverse edges not yet visited
     for w in graph[v]:


### PR DESCRIPTION
Fixed four typos, calling int "uint", added colon after the function signature and removed the "es" within the type Graph declaration.

Added the main method to show the setup to use the depthFirstSearch and better illustrate the two sets, how they are created and used. It took me an hour to figure it out... This may not fit the style of document you want, I've put it in so you have the choice. As it is, you can copy & paste it into Whiley play.
