### PR TITLE
Fixing an example error

### DIFF
--- a/WhileyLanguageSpecification/src/statements.tex
+++ b/WhileyLanguageSpecification/src/statements.tex
@@ -111,7 +111,7 @@ function remove([int] xs, int x) => [int]:
            break
         else:
            i = i + 1
-    return xs[0..i] ++ xs[i..]
+    return xs[0..i] ++ xs[i+1..]
 \end{lstlisting}
 Here, we see a \lstinline{break} statement being used to exit a \lstinline{while} loop when the first element matching parameter \lstinline{x} is found.  
 


### PR DESCRIPTION
the return needs to drop xs[i] from the list. The change ensures it is skipped.
