### PR TITLE
fix explanation to match the example

### DIFF
--- a/WhileyLanguageSpecification/src/compilation-units.tex
+++ b/WhileyLanguageSpecification/src/compilation-units.tex
@@ -141,14 +141,13 @@ operators (e.g. for arithmetic) are permitted.
 
 \lstinputlisting{../examples/ch3/eg_4.whiley}
 
-The first declaration defines the constant \lstinline{PI} to have the
-\lstinline{real} value \lstinline{3.141592654}.  The second
+The first declaration defines the constant \lstinline{TEN} to have the
+\lstinline{real} value \lstinline{10}.  The second
 declaration illustrates a more interesting constant expression which
-is evaluated to \lstinline{6.283185308} at compile time.
+is evaluated to \lstinline{20} at compile time.
 
 \paragraph{Notes.}  A convention is that constants are named in upper
-case with underscores separating words (i.e. as in \lstinline{TWO_PI}
-above).
+case with underscores separating words.
 
 % =======================================================================
 % Function Declarations


### PR DESCRIPTION
The example was changed in 56274592, but the describing text in the spec still referred to the old example code.

This hopefully fixes that.
(I found this while reading the Spec.)